### PR TITLE
Change the spiral color and trace color to match front end color scheme (backlog item)

### DIFF
--- a/app/src/main/java/cmsc436/umd/edu/spiraltest/DrawingView.java
+++ b/app/src/main/java/cmsc436/umd/edu/spiraltest/DrawingView.java
@@ -7,6 +7,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.PorterDuff;
+import android.support.v4.content.ContextCompat;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
@@ -30,7 +31,7 @@ public class DrawingView extends View {
     private void setupDrawing(){
         drawPath = new Path();
         drawPaint = new Paint();
-        drawPaint.setColor(0xFFFF0000);
+        drawPaint.setColor(ContextCompat.getColor(getContext(),R.color.colorAccent));
         drawPaint.setAntiAlias(true);
         drawPaint.setStrokeWidth(40);
         drawPaint.setStyle(Paint.Style.STROKE);

--- a/app/src/main/res/layout/fragment_spiral_test.xml
+++ b/app/src/main/res/layout/fragment_spiral_test.xml
@@ -61,6 +61,6 @@
         android:layout_alignParentEnd="true"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
-        android:alpha="0.5" />
+        android:alpha="0.6" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_spiral_test.xml
+++ b/app/src/main/res/layout/fragment_spiral_test.xml
@@ -12,13 +12,6 @@
     tools:context="cmsc436.umd.edu.spiraltest.SpiralTest">
 
     <TextView
-        android:id="@+id/roundText"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
-        android:textSize="26dp" />
-
-    <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"
@@ -26,16 +19,37 @@
         android:id="@+id/timerText"
         android:layout_below="@+id/roundText"/>
 
-    <cmsc436.umd.edu.spiraltest.DrawingView
-        android:id="@+id/drawView"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:layout_alignBottom="@+id/spiral"
-        android:layout_alignEnd="@+id/spiral"
-        android:layout_alignLeft="@+id/spiral"
-        android:layout_alignRight="@+id/spiral"
-        android:layout_alignStart="@+id/spiral"
-        android:layout_alignTop="@+id/spiral" />
+    <TextView
+        android:id="@+id/roundText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:textSize="26dp" />
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <ImageView
+            android:id="@+id/spiral"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:layout_centerVertical="true"/>
+            <!--android:tint="@color/colorBackground436"-->
+            <!--/>-->
+        <cmsc436.umd.edu.spiraltest.DrawingView
+            android:id="@+id/drawView"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignBottom="@+id/spiral"
+            android:layout_alignEnd="@+id/spiral"
+            android:layout_alignLeft="@+id/spiral"
+            android:layout_alignRight="@+id/spiral"
+            android:layout_alignStart="@+id/spiral"
+            android:layout_alignTop="@+id/spiral" />
+    </FrameLayout>
+
 
     <Button
         android:id="@+id/finish"
@@ -54,13 +68,5 @@
         android:textAlignment="center"
         android:textSize="30dp" />
 
-    <ImageView
-        android:id="@+id/spiral"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
-        android:layout_centerVertical="true"
-        android:alpha="0.6" />
 
 </RelativeLayout>


### PR DESCRIPTION
Changed the trace to blue, since that's in the color palette we're using.

If that colors a bit ugly we can use the orange but up to you guys lmao

The spiral color is actually black in the res folder, but we had it as grey (set the alpha for the imageview) so that the user can see both the trace and the spiral. 

I think that the actual intended behavior is to see the blue trace over the black, which we haven't done. This might've been an oversight where we were displaying them in the same position but not one over the other. So now the trace is over the spiral, which is black.

Black technically isn't in the color palette, but the other option was to use that light grey, which wasn't really easily viewable. Uncomment that line in the layout file to see what that looks like.